### PR TITLE
Fix release GPG import input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
 
       - name: Run GoReleaser


### PR DESCRIPTION
Why

The `v0.8.0` release workflow failed before GoReleaser because `crazy-max/ghaction-import-gpg@v6` expects the `gpg_private_key` input name. The workflow was still using the old hyphenated input.

What changed

- Rename the GPG import input from `gpg-private-key` to `gpg_private_key`.

Verification

- `git diff --check`
- The real verification is rerunning the `v0.8.0` tag workflow after merge.