### PR TITLE
Import GPG key and harden action refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           chmod 600 "$RUNNER_TEMP/gpg-passphrase"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,27 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.gnupg"
+          chmod 700 "$HOME/.gnupg"
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+          fingerprint="$(gpg --batch --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')"
+          if [ -z "$fingerprint" ]; then
+            echo "Could not find imported GPG key fingerprint" >&2
+            exit 1
+          fi
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare GPG passphrase file
+        env:
+          GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GPG_PRIVATE_KEY_PASSPHRASE" > "$RUNNER_TEMP/gpg-passphrase"
+          chmod 600 "$RUNNER_TEMP/gpg-passphrase"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
@@ -35,3 +52,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_PASSPHRASE_FILE: ${{ runner.temp }}/gpg-passphrase

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,8 @@ signs:
       - "--batch"
       - "--pinentry-mode"
       - "loopback"
+      - "--passphrase-file"
+      - "{{ .Env.GPG_PASSPHRASE_FILE }}"
       - "-u"
       - "{{ .Env.GPG_FINGERPRINT }}"
       - "--output"


### PR DESCRIPTION
Why

Release signing is sensitive, so avoid delegating GPG key import to a third-party action when a short shell step can do it directly.

What changed

- Replaces `crazy-max/ghaction-import-gpg` with explicit `gpg --import`.
- Derives the imported secret-key fingerprint for GoReleaser.
- Writes the GPG passphrase to a runner-temp file and passes that file to GoReleaser signing.

Validation

- Ruby YAML parse for `.github/workflows/release.yml`
- `git diff --check`

Additional action reference hardening included here:

- Updates GitHub-owned actions in touched workflows to current major tags.
- Pins retained third-party actions in touched workflows to reviewed commit SHAs, keeping version comments beside each SHA.
